### PR TITLE
Fix for rtrim function

### DIFF
--- a/src/l1/udp_server/main.cpp
+++ b/src/l1/udp_server/main.cpp
@@ -12,7 +12,7 @@
 // Trim from end (in place).
 static inline std::string& rtrim(std::string& s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int c) { return !std::isspace(c); }).base());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int c) { return !std::isspace(c); }).base(),s.end());
     return s;
 }
 


### PR DESCRIPTION
Fix for segfault when string has no trailing spaces at all (i.e. "test" without \n)